### PR TITLE
[#25] Extract each event handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The BOYJ WebRTC signaling server",
   "scripts": {
     "clean": "rimraf ./bin",
-    "test": "mocha test --require babel-polyfill --require babel-register",
+    "test": "mocha test --require babel-polyfill --require babel-register --recursive",
     "build": "babel ./src -d ./bin",
     "start": "npm run build && node ./bin/index.js",
     "eslint-check": "eslint --print-config . | eslint-config-prettier-check"

--- a/src/events/common.js
+++ b/src/events/common.js
@@ -1,0 +1,11 @@
+// It is a handler of 'echo' event. (The event name is echo)
+const echo = socket => (data) => {
+  socket.emit('echo', data);
+};
+
+const dial = socket => () => {
+  socket.emit('created', 'created success');
+};
+
+// module.exports must have event handlers.
+module.exports = { echo, dial };

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -25,9 +25,9 @@
  */
 import * as common from './common';
 
-const isValidHandler = handlers => key => key !== 'default' && typeof handlers[key] === 'function';
+export const isValidHandler = handlers => key => key !== 'default' && typeof handlers[key] === 'function';
 
-const getHandler = handlers => key => ({ name: key, handler: handlers[key] });
+export const getHandler = handlers => key => ({ name: key, handler: handlers[key] });
 
 // Write new handler module here.
 export default

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -1,0 +1,37 @@
+/*
+  This module convert each event handler modules into single array.
+  You can import arbitrary module that contains handlers like below.
+
+  module.exports = {
+    handler1,
+    handler2,
+  };
+
+  In common.js, you can see how it is implemented.
+
+  If you want to import module named 'myHandler.js', try this code.
+
+  import * as myHandler from './myHandler';
+  ...
+  ...
+  export default
+  [common, myHandler]
+    .flatMap(....)
+      .filter(....)
+      .map(....);
+
+   After all, your handler names will be used in event name
+   and handler function will used in event callback function.
+ */
+import * as common from './common';
+
+const isValidHandler = handlers => key => key !== 'default' && typeof handlers[key] === 'function';
+
+const getHandler = handlers => key => ({ name: key, handler: handlers[key] });
+
+// Write new handler module here.
+export default
+[common]
+  .flatMap(handlers => Object.keys(handlers)
+    .filter(isValidHandler(handlers))
+    .map(getHandler(handlers)));

--- a/src/server.js
+++ b/src/server.js
@@ -1,11 +1,9 @@
 import listen from 'socket.io';
+import events from './events';
 
 const addEventListeners = (socket) => {
-  socket.on('echo', (data) => {
-    socket.emit('echo', data);
-  });
-  socket.on('dial', () => {
-    socket.emit('created', 'created success');
+  events.forEach((event) => {
+    socket.on(event.name, event.handler(socket));
   });
 };
 

--- a/test/events/common-spec.js
+++ b/test/events/common-spec.js
@@ -3,7 +3,7 @@ import chai from 'chai';
 import io from 'socket.io-client';
 
 import * as Rx from 'rxjs-compat';
-import Server from '../src/server';
+import Server from '../../src/server';
 
 const { describe, it } = mocha;
 const { assert } = chai;

--- a/test/events/index-spec.js
+++ b/test/events/index-spec.js
@@ -1,0 +1,51 @@
+import * as mocha from 'mocha';
+import chai from 'chai';
+
+import { isValidHandler, getHandler } from '../../src/events';
+
+const { describe, it } = mocha;
+const { expect } = chai;
+
+describe('Tests for invalidHandler()', () => {
+  it('should pass functions except default', (done) => {
+    // given
+    const properties = { default: () => {},
+      func1: () => {},
+      func2: () => {},
+      prop1: 'abc',
+      prop2: '1234' };
+
+    // when
+    const validProperties = Object.keys(properties)
+      .filter(isValidHandler(properties));
+
+    // then
+    expect(properties).to.have.all.keys('default', 'func1', 'func2', 'prop1', 'prop2');
+    expect(validProperties).to.eql(['func1', 'func2']);
+    done();
+  });
+});
+
+describe('Tests for getHandler()', () => {
+  it('should get only functions except default', (done) => {
+    // given
+    const properties = { default: () => {},
+      func1: () => {},
+      func2: () => {},
+      prop1: 'abc',
+      prop2: '1234' };
+
+    // when
+    const validProperties = Object.keys(properties)
+      .filter(isValidHandler(properties))
+      .map(getHandler(properties));
+
+    const expected = [{ name: 'func1', handler: properties.func1 },
+      { name: 'func2', handler: properties.func2 }];
+
+    // then
+    expect(properties).to.have.all.keys('default', 'func1', 'func2', 'prop1', 'prop2');
+    expect(validProperties).to.eql(expected);
+    done();
+  });
+});


### PR DESCRIPTION
We have managed event handlers in a single js file (server.js)

This is not good because server.js has more than one responsibilities.

So, we need to separate these handlers.

This PR is related with #25 .
