### PR TITLE
[#37] Add io object to event handlers

### DIFF
--- a/src/events/call.js
+++ b/src/events/call.js
@@ -1,7 +1,7 @@
 // evaluate to true if it is not null, undefined, NaN, empty string, 0, false
 const isValidData = data => data && data.room;
 
-const dial = socket => (data) => {
+const dial = () => socket => (data) => {
   if (isValidData(data)) {
     socket.emit('created', data);
   } else {
@@ -9,7 +9,7 @@ const dial = socket => (data) => {
   }
 };
 
-const accept = socket => (deviceToken) => {
+const accept = () => socket => (deviceToken) => {
   socket.join(deviceToken);
 };
 

--- a/src/events/common.js
+++ b/src/events/common.js
@@ -1,5 +1,5 @@
 // It is a handler of 'echo' event. (The event name is echo)
-const echo = socket => (data) => {
+const echo = () => socket => (data) => {
   socket.emit('echo', data);
 };
 

--- a/src/events/webrtc.js
+++ b/src/events/webrtc.js
@@ -1,7 +1,7 @@
 // evaluate to true if it is not null, undefined, NaN, empty string, 0, false
 const isValidCandidate = candidate => candidate && candidate.deviceToken;
 
-const sice = socket => (candidate) => {
+const sice = () => socket => (candidate) => {
   if (isValidCandidate(candidate)) {
     socket.to(candidate.deviceToken).emit('rice', candidate);
   } else {

--- a/src/server.js
+++ b/src/server.js
@@ -1,9 +1,9 @@
 import listen from 'socket.io';
 import events from './events';
 
-const addEventListeners = (socket) => {
+const addEventListeners = io => (socket) => {
   events.forEach((event) => {
-    socket.on(event.name, event.handler(socket));
+    socket.on(event.name, event.handler(io)(socket));
   });
 };
 
@@ -14,7 +14,7 @@ class Server {
   }
 
   start() {
-    this.io.on('connection', addEventListeners);
+    this.io.on('connection', addEventListeners(this.io));
     this.io.listen(this.port);
     console.log(`server started at port ${this.port}`);
     return this.io;

--- a/test/events/call-spec.js
+++ b/test/events/call-spec.js
@@ -27,7 +27,7 @@ describe('Call Test', () => {
       const eventName = 'peer_error';
       invalids.forEach((data, index) => {
         // when
-        call.dial(receiver)(data);
+        call.dial()(receiver)(data);
         // then
         assert.equal(receiver.messageBox.length, index + 1);
         assert.equal(receiver.messageBox[index].eventName, eventName);
@@ -49,7 +49,7 @@ describe('Call Test', () => {
       const eventName = 'created';
       const data = { room: roomNumber };
       // when
-      call.dial(receiver)(data);
+      call.dial()(receiver)(data);
       // then
       assert.equal(receiver.messageBox.length, 1);
       assert.equal(receiver.messageBox[0].eventName, eventName);
@@ -69,7 +69,7 @@ describe('Call Test', () => {
       };
       const roomNumber = '12345';
       // when
-      call.accept(receiver)(roomNumber);
+      call.accept()(receiver)(roomNumber);
       // then
       assert.equal(receiver.messageBox.length, 1);
       assert.equal(receiver.messageBox[0], roomNumber);

--- a/test/events/common-spec.js
+++ b/test/events/common-spec.js
@@ -61,7 +61,7 @@ describe('echo()', () => {
     const message = 'message'; // TODO: make it as a random string
 
     // when
-    common.echo(receiver)(message);
+    common.echo()(receiver)(message);
 
     // then
     assert.equal(receiver.messageBox.length, 1);

--- a/test/events/webrtc-spec.js
+++ b/test/events/webrtc-spec.js
@@ -5,72 +5,70 @@ import * as webrtc from '../../src/events/webrtc';
 const { describe, it } = mocha;
 const { assert } = chai;
 
-describe('webrtc tests', () => {
-  describe('Sice Test', () => {
-    describe('Sice Error Test', () => {
-      it('should emit "peer_error" when candidate is invalid', (done) => {
-        // given
-        const receiver = {
-          messageBox: [],
-          emit: (eventName, message) => {
-            const msg = { eventName, message };
-            receiver.messageBox.push(msg);
-          },
-        };
-        const invalids = [
-          undefined,
-          null,
-          {},
-          { deviceToken: '' },
-          { deviceToken: null },
-          { deviceToken: undefined },
-          { sdpMid: 'sdpMid' }, // deviceToken undefined
-        ];
-        const eventName = 'peer_error';
-
-        invalids.forEach((candidate, index) => {
-          // when
-          webrtc.sice(receiver)(candidate);
-          // then
-          assert.equal(receiver.messageBox.length, index + 1);
-          assert.equal(receiver.messageBox[index].eventName, eventName);
-          assert.equal(receiver.messageBox[index].message, candidate);
-        });
-        done();
-      });
-    });
-    describe('Sice Test', () => {
+describe('Sice Test', () => {
+  describe('Sice Error Test', () => {
+    it('should emit "peer_error" when candidate is invalid', (done) => {
       // given
-      const candidate = {
-        deviceToken: '12345',
-        sdpMid: 'IamSDPMid',
-        sdpMLineIndex: '12345',
-        candidate: 'candidate:1234567890 1 udp 0987654321 192.168.0.1',
-      };
       const receiver = {
-        deviceToken: null,
-        messageBox: {},
-        to: (deviceToken) => {
-          receiver.deviceToken = deviceToken;
-          return receiver;
-        },
+        messageBox: [],
         emit: (eventName, message) => {
           const msg = { eventName, message };
-          const token = receiver.deviceToken;
-          if (!receiver.messageBox[token]) {
-            receiver.messageBox[token] = [];
-          }
-          receiver.messageBox[token].push(msg);
+          receiver.messageBox.push(msg);
         },
       };
-      const eventName = 'rice';
-      // when
-      webrtc.sice(receiver)(candidate);
-      // then
-      const { deviceToken } = receiver;
-      assert.equal(receiver.messageBox[deviceToken].length, 1);
-      assert.equal(receiver.messageBox[deviceToken][0].eventName, eventName);
-      assert.deepEqual(receiver.messageBox[deviceToken][0].message, candidate);
+      const invalids = [
+        undefined,
+        null,
+        {},
+        { deviceToken: '' },
+        { deviceToken: null },
+        { deviceToken: undefined },
+        { sdpMid: 'sdpMid' }, // deviceToken undefined
+      ];
+      const eventName = 'peer_error';
+
+      invalids.forEach((candidate, index) => {
+        // when
+        webrtc.sice()(receiver)(candidate);
+        // then
+        assert.equal(receiver.messageBox.length, index + 1);
+        assert.equal(receiver.messageBox[index].eventName, eventName);
+        assert.equal(receiver.messageBox[index].message, candidate);
+      });
+      done();
     });
+  });
+  describe('Sice Test', () => {
+    // given
+    const candidate = {
+      deviceToken: '12345',
+      sdpMid: 'IamSDPMid',
+      sdpMLineIndex: '12345',
+      candidate: 'candidate:1234567890 1 udp 0987654321 192.168.0.1',
+    };
+    const receiver = {
+      deviceToken: null,
+      messageBox: {},
+      to: (deviceToken) => {
+        receiver.deviceToken = deviceToken;
+        return receiver;
+      },
+      emit: (eventName, message) => {
+        const msg = { eventName, message };
+        const token = receiver.deviceToken;
+        if (!receiver.messageBox[token]) {
+          receiver.messageBox[token] = [];
+        }
+        receiver.messageBox[token].push(msg);
+      },
+    };
+    const eventName = 'rice';
+    // when
+    webrtc.sice()(receiver)(candidate);
+    // then
+    const { deviceToken } = receiver;
+    assert.equal(receiver.messageBox[deviceToken].length, 1);
+    assert.equal(receiver.messageBox[deviceToken][0].eventName, eventName);
+    assert.deepEqual(receiver.messageBox[deviceToken][0].message, candidate);
   });
 });


### PR DESCRIPTION
본 pull request는 #37 과 관련있습니다.

기존의 이벤트 핸들러들은 socket 객체만 필요로 하였으나,
```socket.io```의 많은 기능이 io 객체로 부터 제공되므로
추후의 기능을 위해 io 객체를 추가적으로 받을 필요가 있어보입니다.

따라서 io 객체를 각 핸들러에 인자로 넣는 코드를 추가하였습니다.