### PR TITLE
Event handlers pass arguments as a form of RORO pattern

### DIFF
--- a/src/events/call.js
+++ b/src/events/call.js
@@ -20,7 +20,7 @@ const hasFullParticipants = ({ io, room }) => getParticipantsCount({ io, room })
 const preparedToRtcCall = ({ io, room }) => isValidData({ io, room })
   && hasFullParticipants({ io, room });
 
-const dial = () => caller => ({ deviceToken }) => {
+const dial = ({ socket: caller }) => ({ deviceToken }) => {
   if (deviceToken) {
     const room = uuid.v1();
     caller.join(room);
@@ -31,7 +31,7 @@ const dial = () => caller => ({ deviceToken }) => {
   }
 };
 
-const defaultAwaken = canParticipate => io => callee => ({ room }) => {
+const defaultAwaken = canParticipate => ({ io, socket: callee }) => ({ room }) => {
   if (canParticipate({ io, room })) {
     const caller = callee.to(room);
     caller.emit('created');
@@ -44,7 +44,7 @@ const defaultAwaken = canParticipate => io => callee => ({ room }) => {
 
 const awaken = defaultAwaken(isWaitingCallee);
 
-const defaultAccept = canBeReady => io => () => ({ room }) => {
+const defaultAccept = canBeReady => ({ io }) => ({ room }) => {
   if (canBeReady({ io, room })) {
     io.in(room).emit('ready');
   } else {
@@ -54,7 +54,7 @@ const defaultAccept = canBeReady => io => () => ({ room }) => {
 
 const accept = defaultAccept(preparedToRtcCall);
 
-const reject = io => () => ({ room }) => {
+const reject = ({ io }) => ({ room }) => {
   io.in(room).emit('bye');
 };
 

--- a/src/events/common.js
+++ b/src/events/common.js
@@ -1,5 +1,5 @@
 // It is a handler of 'echo' event. (The event name is echo)
-const echo = () => socket => (data) => {
+const echo = ({ socket }) => (data) => {
   socket.emit('echo', data);
 };
 

--- a/src/events/webrtc.js
+++ b/src/events/webrtc.js
@@ -1,7 +1,7 @@
 // evaluate to true if it is not null, undefined, NaN, empty string, 0, false
 const isValidCandidate = candidate => candidate && candidate.deviceToken;
 
-const sice = () => socket => (candidate) => {
+const sice = ({ socket }) => (candidate) => {
   if (isValidCandidate(candidate)) {
     socket.to(candidate.deviceToken).emit('rice', candidate);
   } else {

--- a/src/events/webrtc.js
+++ b/src/events/webrtc.js
@@ -1,11 +1,12 @@
 // evaluate to true if it is not null, undefined, NaN, empty string, 0, false
 const isValidCandidate = candidate => candidate && candidate.deviceToken;
 
-const sice = ({ socket }) => (candidate) => {
+const sice = ({ socket: sender }) => (candidate) => {
   if (isValidCandidate(candidate)) {
-    socket.to(candidate.deviceToken).emit('rice', candidate);
+    const receivers = sender.to(candidate.deviceToken);
+    receivers.emit('rice', candidate);
   } else {
-    socket.emit('peer_error', candidate);
+    sender.emit('peer_error', candidate);
   }
 };
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,9 +1,9 @@
 import listen from 'socket.io';
 import events from './events';
 
-const addEventListeners = io => (socket) => {
+const addEventListeners = ({ io, weakMap }) => (socket) => {
   events.forEach((event) => {
-    socket.on(event.name, event.handler(io)(socket));
+    socket.on(event.name, event.handler({ io, socket, weakMap }));
   });
 };
 
@@ -14,10 +14,13 @@ class Server {
   }
 
   start() {
-    this.io.on('connection', addEventListeners(this.io));
-    this.io.listen(this.port);
+    const { io } = this;
+    const weakMap = new WeakMap();
+
+    io.on('connection', addEventListeners({ io, weakMap }));
+    io.listen(this.port);
     console.log(`server started at port ${this.port}`);
-    return this.io;
+    return io;
   }
 
   close() {

--- a/test/events/call-spec.js
+++ b/test/events/call-spec.js
@@ -35,7 +35,7 @@ describe('Call Test', () => {
           message: { description: `Invalid device token. ${deviceToken}` },
         };
         // when
-        call.dial()(receiver)({ deviceToken });
+        call.dial({ socket: receiver })({ deviceToken });
         // then
         assert.equal(receiver.messageBox.length, index + 1);
         assert.equal(receiver.messageBox[index].eventName, eventName);
@@ -55,7 +55,7 @@ describe('Call Test', () => {
       const deviceToken = '12345';
 
       // when
-      call.dial()(receiver)({ deviceToken });
+      call.dial({ socket: receiver })({ deviceToken });
 
       // then
       assert.equal(receiver.rooms.length, 1);
@@ -83,7 +83,7 @@ describe('Call Test', () => {
       const accept = call.helper.defaultAccept(() => true);
 
       // when
-      accept(sockets)()({ room: roomName });
+      accept({ io: sockets })({ room: roomName });
 
       // then
       assert.equal(sockets.emitTargets.length, 1);
@@ -116,7 +116,7 @@ describe('Call Test', () => {
       };
 
       // when
-      accept(sockets)()({ room: roomName });
+      accept({ io: sockets })({ room: roomName });
 
       // then
       assert.equal(sockets.emitTargets.length, 1);
@@ -144,7 +144,7 @@ describe('Call Test', () => {
       const roomName = uuid.v1();
 
       // when
-      call.reject(sockets)()({ room: roomName });
+      call.reject({ io: sockets })({ room: roomName });
 
       // then
       assert.equal(sockets.emitTargets.length, 1);
@@ -176,7 +176,7 @@ describe('Call Test', () => {
       const awaken = call.helper.defaultAwaken(() => true);
 
       // when
-      awaken()(callee)({ room: roomName });
+      awaken({ socket: callee })({ room: roomName });
 
       // then
       assert.equal(callee.rooms.length, 1);
@@ -205,7 +205,7 @@ describe('Call Test', () => {
       };
 
       // when
-      awaken()(callee)({ room: roomName });
+      awaken({ socket: callee })({ room: roomName });
 
       // then
       assert.equal(callee.messageBox.length, 1);

--- a/test/events/common-spec.js
+++ b/test/events/common-spec.js
@@ -61,7 +61,7 @@ describe('echo()', () => {
     const message = 'message'; // TODO: make it as a random string
 
     // when
-    common.echo()(receiver)(message);
+    common.echo({ socket: receiver })(message);
 
     // then
     assert.equal(receiver.messageBox.length, 1);

--- a/test/events/webrtc-spec.js
+++ b/test/events/webrtc-spec.js
@@ -29,7 +29,7 @@ describe('Sice Test', () => {
 
       invalids.forEach((candidate, index) => {
         // when
-        webrtc.sice()(receiver)(candidate);
+        webrtc.sice({ socket: receiver })(candidate);
         // then
         assert.equal(receiver.messageBox.length, index + 1);
         assert.equal(receiver.messageBox[index].eventName, eventName);
@@ -64,7 +64,7 @@ describe('Sice Test', () => {
     };
     const eventName = 'rice';
     // when
-    webrtc.sice()(receiver)(candidate);
+    webrtc.sice({ socket: receiver })(candidate);
     // then
     const { deviceToken } = receiver;
     assert.equal(receiver.messageBox[deviceToken].length, 1);


### PR DESCRIPTION
이 pull request는 #46 와 연관되어있습니다.

이벤트 핸들러의 매개변수들을 RORO 형태로 받게 하여 추가적인 인자가 필요할 경우 최소한의 수정을 통해 핸들러가 인자를 받을 수 있게 했습니다.

추가적으로 socket.io의 방 정보를 담고있는 ```weakMap```을 해당 매개변수를 통해 받을 수 있게 하였습니다.