### PR TITLE
[#48] Remove flatMap in events/index.js

### DIFF
--- a/src/events/index.js
+++ b/src/events/index.js
@@ -32,8 +32,13 @@ export const isValidHandler = handlers => key => key !== 'default' && typeof han
 export const getHandler = handlers => key => ({ name: key, handler: handlers[key] });
 
 // Write new handler module here.
-export default
+const events = [];
 [common, call, webrtc]
-  .flatMap(handlers => Object.keys(handlers)
+  .forEach(handlers => Object.keys(handlers)
     .filter(isValidHandler(handlers))
-    .map(getHandler(handlers)));
+    .map(getHandler(handlers))
+    .forEach((handler) => {
+      events.push(handler);
+    }));
+
+export default events;


### PR DESCRIPTION
Because ```flatMap()``` is a experimental feature, signaling server sometimes
break down depending on runtime environment. So, I need to remove this function.

This commit replaces ```flatMap()``` into other es6 array functions (map,
filter etc). As these functions are already in es6 standards, I hope that we will
never encounter the similar issue again.