### PR TITLE
[#75]Fix some validations based on v1.x

### DIFF
--- a/src/events/call.js
+++ b/src/events/call.js
@@ -3,7 +3,7 @@ import * as manager from '../firebase/manager';
 import logger from '../logger';
 
 // evaluate to true if it is not null, undefined, NaN, empty string, 0, false
-const isValidData = data => data && data.room;
+const isValidData = data => data;
 
 // get the number of participants in the room
 const getParticipantsCount = ({ io, room }) => {
@@ -21,7 +21,7 @@ const preparedToRtcCall = ({ io, room }) => isValidData({ io, room })
   && hasFullParticipants({ io, room });
 
 const dial = ({ socket: caller, weakMap }) => ({ deviceToken }) => {
-  logger.trace(`dial() is called with device token: ${deviceToken}`);
+  logger.info(`dial() is called with device token: ${deviceToken}`);
 
   if (isValidData(deviceToken)) {
     const room = uuid.v1();
@@ -35,7 +35,7 @@ const dial = ({ socket: caller, weakMap }) => ({ deviceToken }) => {
         token: deviceToken,
       })
       .then((response) => {
-        logger.trace(`dial() fcm sent message successfully: ${response}`);
+        logger.info(`dial() fcm sent message successfully: ${response}`);
       })
       .catch((error) => {
         caller.emit('serverError', { description: error.message });
@@ -51,7 +51,7 @@ const dial = ({ socket: caller, weakMap }) => ({ deviceToken }) => {
 const defaultAwaken = canParticipate => ({
   io, socket: callee, weakMap,
 }) => ({ room }) => {
-  logger.trace(`awaken() is called with room: ${room}`);
+  logger.info(`awaken() is called with room: ${room}`);
 
   if (canParticipate({ io, room })) {
     const caller = callee.to(room);
@@ -70,7 +70,7 @@ const defaultAccept = canBeReady => ({
   io, socket: callee, weakMap,
 }) => () => {
   const { room } = weakMap.get(callee);
-  logger.trace(`accept is called with room: ${room}`);
+  logger.info(`accept is called with room: ${room}`);
 
   if (canBeReady({ io, room })) {
     io.in(room).emit('ready');
@@ -85,7 +85,7 @@ const reject = ({
   io, socket: callee, weakMap,
 }) => () => {
   const { room } = weakMap.get(callee);
-  logger.trace(`reject is called with reject: ${room}`);
+  logger.info(`reject is called with reject: ${room}`);
   io.in(room).emit('bye');
 };
 

--- a/src/events/webrtc.js
+++ b/src/events/webrtc.js
@@ -3,7 +3,7 @@ import logger from '../logger';
 const isValidSdp = sdp => sdp;
 
 const defaultSsdp = isValid => ({ socket: sender, weakMap }) => (sdp) => {
-  logger.trace(`sendSDP is called with sdp: ${sdp}`);
+  logger.info(`sendSDP is called with sdp: ${sdp}`);
 
   if (isValid(sdp)) {
     const { room } = weakMap.get(sender);
@@ -17,7 +17,7 @@ const defaultSsdp = isValid => ({ socket: sender, weakMap }) => (sdp) => {
 const ssdp = defaultSsdp(isValidSdp);
 
 const defaultSice = isValid => ({ socket: sender, weakMap }) => (candidate) => {
-  logger.trace(`send ICECandidate is called with ice: ${candidate}`);
+  logger.info(`send ICECandidate is called with ice: ${candidate}`);
 
   if (isValid(candidate)) {
     const { room } = weakMap.get(sender);


### PR DESCRIPTION
This PR is related with #75 

**Abstract**
v1.x 스펙에 맞는 페이로드 유효성 검사를 위한 풀리퀘스트입니다.

**As Is**
```javascript
const isValidData = data => data && data.room;
```

**To Be**
인자의 존재 여부만 확인하며 deviceToken은 destructuring에 의해 여부 판단
```javascript
const isValidData = data => data;
```

추가로 배포 상황에서 로그 출력을 위해 trace에 해당하는 로그 수준을 info로 조정하였습니다.