### PR TITLE
[#80] 세션 제어 이벤트 (create room) v2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The BOYJ WebRTC signaling server",
   "scripts": {
     "clean": "rimraf ./bin",
-    "test": "mocha test --require babel-polyfill --require babel-register --recursive",
+    "test": "mocha \"./src/**/*.test.js\" --require babel-polyfill --require babel-register --recursive",
     "build": "babel ./src -d ./bin",
     "start": "npm run build && node ./bin/index.js",
     "eslint-check": "eslint --print-config . | eslint-config-prettier-check"

--- a/src/boyj/session_control_events.js
+++ b/src/boyj/session_control_events.js
@@ -1,0 +1,74 @@
+/**
+ * 커넥션 연결 시 소켓에 매핑될 세션객체를 초기화하는 함수
+ *
+ * @param defaultSession
+ * @returns {{user: undefined, room: undefined}}
+ */
+const createSession = (defaultSession) => {
+  const session = {
+    room: undefined,
+    user: undefined,
+  };
+  Object.assign(session, defaultSession);
+  return session;
+};
+
+/**
+ * caller의 방 생성 요청 이벤트(create room)의 핸들러 함수이다.
+ * 세션 생성 후 처음으로 caller 정보 및 room 정보를 받을 수 있기 때문에
+ * 이를 세션 객체에 저장해둔다.
+ *
+ * @param session
+ * @returns {Function}
+ */
+const createRoom = session => (payload) => {
+  if (!payload) {
+    throw new Error(`Invalid payload. payload: ${payload}`);
+  }
+
+  const {
+    room,
+    callerId,
+  } = payload;
+
+  if (!room || !callerId) {
+    throw new Error(`Invalid payload. room: ${room}, callerId: ${callerId}`);
+  }
+
+  const extraSessionInfo = {
+    room,
+    user: callerId,
+  };
+
+  Object.assign(session, extraSessionInfo);
+
+  const { socket } = session;
+
+  socket.join(room);
+};
+
+/**
+ * create room 이벤트에서 에러 발생 시 에러 핸들러
+ * payload의 validation 에러 외에는 발생하지 않으므로
+ * 잘못된 payload 에러를 전달한다.
+ *
+ * @param err
+ * @param context
+ */
+const createRoomErrorHandler = (err, context) => {
+  const { session } = context;
+  const { socket } = session;
+  const payload = {
+    code: 301,
+    description: 'Invalid Create Room Payload',
+    message: err.message,
+  };
+
+  socket.emit('SERVER_TO_PEER_ERROR', payload);
+};
+
+export {
+  createSession,
+  createRoom,
+  createRoomErrorHandler,
+};

--- a/src/boyj/session_control_events.test.js
+++ b/src/boyj/session_control_events.test.js
@@ -1,0 +1,103 @@
+/* eslint-disable no-unused-expressions */
+const chai = require('chai');
+
+const { expect } = chai;
+const chaiAsPromise = require('chai-as-promised');
+
+chai.use(chaiAsPromise);
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+
+chai.use(sinonChai);
+
+const events = require('./session_control_events');
+
+describe('session_control_events', () => {
+  const io = {};
+  const socket = {
+    join: () => {},
+    emit: () => {},
+  };
+  const fakeSession = {
+    io,
+    socket,
+  };
+
+  context('createSession', () => {
+    it('should create session including boyj session properties', () => {
+      const session = events.createSession();
+
+      expect(session).to.have.property('room').with.not.exist;
+      expect(session).to.have.property('user').with.not.exist;
+    });
+
+    it('should create session including defaultSession', () => {
+      const fakeDefaultSession = { foo: 'fake foo', bar: 'fake bar' };
+      const session = events.createSession(fakeDefaultSession);
+
+      expect(session).to.deep.include(fakeDefaultSession);
+    });
+  });
+
+  context('createRoom', () => {
+    it('should occur error if payload is undefined', () => {
+      const errorMessage = `Invalid payload. payload: ${undefined}`;
+
+      expect(events.createRoom(fakeSession).bind(this)).to.throw(errorMessage);
+    });
+
+    it('should occur error if payload is not verified', () => {
+      const invalidPayloads = [
+        {},
+        { room: 'fake room', callerId: undefined },
+        { room: undefined, callerId: 'fake callerId' },
+      ];
+
+      invalidPayloads.forEach((payload) => {
+        const errorMessage = `Invalid payload. room: ${payload.room}, callerId: ${payload.callerId}`;
+
+        expect(events.createRoom(fakeSession).bind(this, payload)).to.throw(errorMessage);
+      });
+    });
+
+    it('should assign session info and join into the room', () => {
+      const fakePayload = {
+        room: 'fake room',
+        callerId: 'fake callerId',
+      };
+      const joinStub = sinon.stub(socket, 'join').callsFake(() => {});
+
+      events.createRoom(fakeSession)(fakePayload);
+
+      expect(fakeSession).to.have.property('room').with.equal('fake room');
+      expect(fakeSession).to.have.property('user').with.equal('fake callerId');
+      expect(joinStub).to.be.calledOnce;
+      expect(joinStub).to.be.calledWith('fake room');
+
+      joinStub.restore();
+    });
+  });
+
+  context('createRoomErrorHandler', () => {
+    it('should emit error message to sender', () => {
+      const fakePayload = {};
+      const fakeContext = {
+        session: fakeSession,
+        payload: fakePayload,
+      };
+      const fakeError = { message: 'fake error message' };
+      const emitStub = sinon.stub(socket, 'emit').callsFake(() => {});
+
+      events.createRoomErrorHandler(fakeError, fakeContext);
+
+      expect(emitStub).to.be.calledOnce;
+      expect(emitStub).to.be.calledWith('SERVER_TO_PEER_ERROR', {
+        code: 301,
+        description: 'Invalid Create Room Payload',
+        message: 'fake error message',
+      });
+
+      emitStub.restore();
+    });
+  });
+});


### PR DESCRIPTION
[v2.0](https://github.com/the-boyj/wiki/wiki/Message-Payload-v2.0---draft)스펙의 세션 제어 이벤트들 중 create room을 구현하였습니다.
세션 제어 이벤트는 다음을 참고 바랍니다. #80  

추가적으로 세션 생성을 위한 createSession 함수 역시 구현하였습니다.