### PR TITLE
session control events v2 (dial)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,37 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/6ec8dc4732044691b575299092d18161)](https://www.codacy.com/app/the-boyj/signaling-server?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=the-boyj/signaling-server&amp;utm_campaign=Badge_Grade)
 
-# After clone
-```zsh
-rm -rf .git && git init && npm install
-
-// If you want to config pre-commit for checking eslint
-cp ./resource/hooks/* ./.git/hooks/
+## Execution
+* Run server
+```sh
+FIREBASE_DATABASE_URL=<firebase-database-url> \
+FIREBASE_ACCOUNT_TYPE=<firebase-account-type> \
+FIREBASE_ACCOUNT_PROJECT_ID=<firebase-account-project-id> \
+FIREBASE_ACCOUNT_PRIVATE_KEY_ID=<firebase-account-private-key-id> \
+FIREBASE_ACCOUNT_PRIVATE_KEY=<firebase-account-private-key> \
+FIREBASE_ACCOUNT_CLIENT_EMAIL=<firebase-account-client-email> \
+FIREBASE_ACCOUNT_CLIENT_ID=<firebase-account-client-id> \
+FIREBASE_ACCOUNT_AUTH_URI=<firebase-account-auth-uri> \
+FIREBASE_ACCOUNT_TOKEN_URI=<firebase-account-token-uri> \
+FIREBASE_ACCOUNT_AUTH_PROVIDER_X509_CERT_URL=<firebase-account-auth-provider-x509-cer-url> \
+FIREBASE_ACCOUNT_CLIENT_X509_CERT_URL=<firebase-account-client-x509-cert-url> \
+REDIS_HOST=<redis-host> \
+REDIS_PORT=<redis-port> \
+npm start
 ```
-
-# Execution
-* npm start
-* npm test (run all unit tests with mocha)
-
-# Debug (in Intellij)
-![](./resource/debug_start.jpg)
-![](./resource/debug_test.jpg)
+* Run tests with Mocha
+```sh
+FIREBASE_DATABASE_URL=<firebase-database-url> \
+FIREBASE_ACCOUNT_TYPE=<firebase-account-type> \
+FIREBASE_ACCOUNT_PROJECT_ID=<firebase-account-project-id> \
+FIREBASE_ACCOUNT_PRIVATE_KEY_ID=<firebase-account-private-key-id> \
+FIREBASE_ACCOUNT_PRIVATE_KEY=<firebase-account-private-key> \
+FIREBASE_ACCOUNT_CLIENT_EMAIL=<firebase-account-client-email> \
+FIREBASE_ACCOUNT_CLIENT_ID=<firebase-account-client-id> \
+FIREBASE_ACCOUNT_AUTH_URI=<firebase-account-auth-uri> \
+FIREBASE_ACCOUNT_TOKEN_URI=<firebase-account-token-uri> \
+FIREBASE_ACCOUNT_AUTH_PROVIDER_X509_CERT_URL=<firebase-account-auth-provider-x509-cer-url> \
+FIREBASE_ACCOUNT_CLIENT_X509_CERT_URL=<firebase-account-client-x509-cert-url> \
+REDIS_HOST=<redis-host> \
+REDIS_PORT=<redis-port> \
+npm test 
+```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The BOYJ WebRTC signaling server",
   "scripts": {
     "clean": "rimraf ./bin",
-    "test": "mocha \"./src/**/*.test.js\" --require babel-polyfill --require babel-register --recursive",
+    "test": "mocha \"./src/**/*.test.js\" --require babel-polyfill --require babel-register --recursive --exit",
     "build": "babel ./src -d ./bin",
     "start": "npm run build && node ./bin/index.js",
     "eslint-check": "eslint --print-config . | eslint-config-prettier-check"
@@ -51,8 +51,10 @@
   },
   "dependencies": {
     "babel-polyfill": "^6.26.0",
+    "bluebird": "^3.5.4",
     "firebase-admin": "^6.5.1",
     "pino": "^5.11.2",
+    "redis": "^2.8.0",
     "socket.io": "^2.2.0",
     "uuid": "^3.3.2"
   }

--- a/src/boyj/config.js
+++ b/src/boyj/config.js
@@ -1,0 +1,21 @@
+export default {
+  firebase: {
+    databaseURL: process.env.FIREBASE_DATABASE_URL,
+    accountPath: {
+      type: process.env.FIREBASE_ACCOUNT_TYPE,
+      project_id: process.env.FIREBASE_ACCOUNT_PROJECT_ID,
+      private_key_id: process.env.FIREBASE_ACCOUNT_PRIVATE_KEY_ID,
+      private_key: process.env.FIREBASE_ACCOUNT_PRIVATE_KEY.replace(/\\n/g, '\n'),
+      client_email: process.env.FIREBASE_ACCOUNT_CLIENT_EMAIL,
+      client_id: process.env.FIREBASE_ACCOUNT_CLIENT_ID,
+      auth_uri: process.env.FIREBASE_ACCOUNT_AUTH_URI,
+      token_uri: process.env.FIREBASE_ACCOUNT_TOKEN_URI,
+      auth_provider_x509_cert_url: process.env.FIREBASE_ACCOUNT_AUTH_PROVIDER_X509_CERT_URL,
+      client_x509_cert_url: process.env.FIREBASE_ACCOUNT_CLIENT_X509_CERT_URL,
+    },
+  },
+  redisOptions: {
+    host: process.env.REDIS_HOST,
+    port: process.env.REDIS_PORT,
+  },
+};

--- a/src/boyj/model/data_source.js
+++ b/src/boyj/model/data_source.js
@@ -1,0 +1,12 @@
+import * as Redis from 'redis';
+import * as Promise from 'bluebird';
+import config from '../config';
+
+const { redisOptions } = config;
+
+Promise.promisifyAll(Redis.RedisClient.prototype);
+Promise.promisifyAll(Redis.Multi.prototype);
+
+const redis = Redis.createClient(redisOptions);
+
+export default redis;

--- a/src/boyj/notification_messaging.js
+++ b/src/boyj/notification_messaging.js
@@ -1,0 +1,18 @@
+import * as firebaseAdmin from 'firebase-admin';
+import 'babel-polyfill';
+import config from './config';
+
+const { firebase } = config;
+const {
+  databaseURL,
+  accountPath,
+} = firebase;
+
+const credential = firebaseAdmin.credential.cert(accountPath);
+
+const firebaseApp = firebaseAdmin.initializeApp({
+  databaseURL,
+  credential,
+});
+
+export default firebaseApp.messaging();

--- a/src/boyj/session_control_events.js
+++ b/src/boyj/session_control_events.js
@@ -1,3 +1,6 @@
+import redis from './model/data_source';
+import notification from './notification_messaging';
+
 /**
  * 커넥션 연결 시 소켓에 매핑될 세션객체를 초기화하는 함수
  *
@@ -67,8 +70,94 @@ const createRoomErrorHandler = (err, context) => {
   socket.emit('SERVER_TO_PEER_ERROR', payload);
 };
 
+/**
+ * caller의 통화 연결 요청(dial) 이벤트 핸들러이다.
+ * fcm을 이용하여 상대에게 알림 요청이 되며
+ * skipNotification 설정시 별 다른 행동 없이 종료된다.
+ *
+ * @param session
+ * @returns {Function}
+ */
+const dialToCallee = session => async (payload) => {
+  // TODO: session, payload 유효성 검사 로직 분리 필요.
+  if (!payload) {
+    throw new Error(`Invalid payload. payload: ${payload}`);
+  }
+
+  const {
+    calleeId,
+    skipNotification = false,
+  } = payload;
+
+  if (!calleeId) {
+    throw new Error(`Invalid payload. calleeId: ${calleeId}`);
+  }
+
+  if (skipNotification) {
+    return;
+  }
+
+  // notification routine
+  const {
+    room,
+    user: caller,
+  } = session;
+
+  if (!room || !caller) {
+    throw new Error(`The session is not initialized. room: ${room}, user: ${caller}`);
+  }
+
+  // TODO: 유저 정보 연동 로직 -> 서비스 레이어로 추상화 필요(RESTful api위해)
+  const callee = await redis.hgetallAsync(`user:${calleeId}`);
+
+  if (!callee) {
+    throw new Error(`There is no user data for user ${calleeId}`);
+  }
+
+  const { deviceToken } = callee;
+
+  if (!deviceToken) {
+    throw new Error(`There is no available deviceToken for user ${calleeId}`);
+  }
+
+  await notification.send({
+    data: {
+      room,
+      caller: { tel: caller },
+    },
+    android: { priority: 'high' },
+    token: deviceToken,
+  });
+};
+
+/**
+ * 통화 요청 이벤트(dial)의 에러 핸들러
+ * 잘못된 payload의 경우 302 에러를 보내며
+ * 그 외의 경우에는 알 수 없는 서버 에러로 전달하게 된다.
+ *
+ * @param err
+ * @param context
+ */
+const dialToCalleeErrorHandler = (err, context) => {
+  const { message } = err;
+  const { session } = context;
+  const { socket } = session;
+
+  // TODO: 이후 Error를 상속한 다른 에러 클래스로 분기 필요
+  const isPayloadError = /^Invalid payload\.*/.test(message);
+  const payload = {
+    code: isPayloadError ? 302 : 300,
+    description: isPayloadError ? 'Invalid Dial Payload' : 'Internal Server Error',
+    message,
+  };
+
+  socket.emit('SERVER_TO_PEER_ERROR', payload);
+};
+
 export {
   createSession,
   createRoom,
   createRoomErrorHandler,
+  dialToCallee,
+  dialToCalleeErrorHandler,
 };


### PR DESCRIPTION
* Abstract
이전 PR에 codacy와 관련된 문제로 인해 다시 작성합니다.
#80 의 dial 이벤트를 구현하였습니다.

* As Is
각 유저가 상대 device token을 알아야 했고, 이로 인해 앱에서 데이터 소스에 접근해야 했음

* To Be
유저는 서비스상 유니크한 상대 키값을 갖고있으며, 이를 서버에 전달
서버는 이 키값을 이용하여 데이터 소스로부터 사용자 정보 획득 및 알림.