### PR TITLE
[#81] Implement Session Establishment Events v2.0

### DIFF
--- a/src/boyj/session_establishment_events.js
+++ b/src/boyj/session_establishment_events.js
@@ -1,0 +1,193 @@
+/**
+ * accept 이벤트의 핸들러
+ *
+ * @param session
+ * @returns {Function}
+ */
+const acceptFromCallee = session => (payload) => {
+  if (!payload) {
+    throw new Error(`Invalid payload. payload: ${payload}`);
+  }
+
+  const { sdp } = payload;
+
+  if (!sdp) {
+    throw new Error(`Invalid payload. sdp: ${sdp}`);
+  }
+
+  // TODO: session 객체에 대한 유효성 검사 필요.
+  const {
+    user,
+    room,
+    socket,
+  } = session;
+
+  const relayOfferPayload = {
+    sender: user,
+    sdp,
+  };
+
+  // 송신자를 제외한 나머지 클라이언트에 브로드캐스팅
+  socket.to(room).emit('relay offer', relayOfferPayload);
+};
+
+/**
+ * accept 이벤트의 에러 핸들러
+ *
+ * @param err
+ * @param context
+ */
+const acceptFromCalleeErrorHandler = (err, context) => {
+  const { message } = err;
+  const { session } = context;
+  const { socket } = session;
+  const payload = {
+    code: 304,
+    description: 'Invalid Accept Payload',
+    message,
+  };
+
+  socket.emit('SERVER_TO_PEER_ERROR', payload);
+};
+
+/**
+ * reject 이벤트 핸들러
+ *
+ * @param session
+ * @returns {Function}
+ */
+const rejectFromCallee = session => () => {
+  const {
+    room,
+    user,
+    socket,
+  } = session;
+
+  const byeEventPayload = { sender: user };
+
+  // TODO: 세션 유효성 검사 필요.
+  // TODO: room이 아닌 caller에 보내는게 더 좋아보임.
+  socket.to(room).emit('bye', byeEventPayload);
+};
+
+/**
+ * send answer 이벤트 핸들러
+ *
+ * @param session
+ * @returns {Function}
+ */
+const answerFromClient = session => (payload) => {
+  if (!payload) {
+    throw new Error(`Invalid payload. payload: ${payload}`);
+  }
+
+  const {
+    sdp,
+    receiver,
+  } = payload;
+
+  if (!sdp || !receiver) {
+    throw new Error(`Invalid payload. sdp: ${sdp}, receiver: ${receiver}`);
+  }
+
+  // TODO: 세션 유효성 검사 필요.
+  const {
+    user,
+    socket,
+  } = session;
+
+  const relayAnswerPayload = {
+    sdp,
+    receiver,
+    sender: user,
+  };
+
+  // TODO: createRoom, awaken에서 user:userId 방 생성 필요
+  // TODO: bye에서 user:userId release 필요.
+  socket.to(`user:${receiver}`).emit('relay answer', relayAnswerPayload);
+};
+
+/**
+ * send answer 이벤트의 에러 핸들러
+ *
+ * @param err
+ * @param context
+ */
+const answerFromClientErrorHandler = (err, context) => {
+  const { message } = err;
+  const { session } = context;
+  const { socket } = session;
+  const errorPayload = {
+    code: 305,
+    description: 'Invalid Send Answer Payload',
+    message,
+  };
+
+  socket.emit('SERVER_TO_PEER_ERROR', errorPayload);
+};
+
+/**
+ * send icecandidate 이벤트 핸들러
+ *
+ * @param session
+ * @returns {Function}
+ */
+const icecandidateFromClient = session => (payload) => {
+  if (!payload) {
+    throw new Error(`Invalid payload. payload: ${payload}`);
+  }
+
+  const {
+    iceCandidate,
+    receiver,
+  } = payload;
+
+  if (!iceCandidate || !receiver) {
+    throw new Error(`Invalid payload. iceCandidate: ${iceCandidate}, receiver: ${receiver}`);
+  }
+
+  // TODO: 세션 유효성 검사 필요.
+  const {
+    user,
+    socket,
+  } = session;
+
+  const relayIcecandidatePayload = {
+    iceCandidate,
+    receiver,
+    sender: user,
+  };
+
+  // TODO: createRoom, awaken에서 user:userId 방 생성 필요
+  // TODO: bye에서 user:userId release 필요.
+  socket.to(`user:${receiver}`).emit('relay icecandidate', relayIcecandidatePayload);
+};
+
+/**
+ * send icecandidate 이벤트의 에러 핸들러
+ *
+ * @param err
+ * @param context
+ */
+const icecandidateFromClientErrorHandler = (err, context) => {
+  const { message } = err;
+  const { session } = context;
+  const { socket } = session;
+  const errorPayload = {
+    code: 306,
+    description: 'Invalid Send Icecandidate Payload',
+    message,
+  };
+
+  socket.emit('SERVER_TO_PEER_ERROR', errorPayload);
+};
+
+export {
+  acceptFromCallee,
+  acceptFromCalleeErrorHandler,
+  rejectFromCallee,
+  answerFromClient,
+  answerFromClientErrorHandler,
+  icecandidateFromClient,
+  icecandidateFromClientErrorHandler,
+};

--- a/src/boyj/session_establishment_events.test.js
+++ b/src/boyj/session_establishment_events.test.js
@@ -1,0 +1,234 @@
+/* eslint-disable no-unused-expressions */
+const chai = require('chai');
+
+const { expect } = chai;
+const chaiAsPromise = require('chai-as-promised');
+
+chai.use(chaiAsPromise);
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+
+chai.use(sinonChai);
+
+const events = require('./session_establishment_events');
+
+describe('session_establishment_events', () => {
+  const io = {};
+  const socket = {
+    join: () => {},
+    emit: () => {},
+    to: () => {},
+  };
+  let fakeSession;
+  let emitStub;
+  let toStub;
+
+  beforeEach(() => {
+    fakeSession = {
+      io,
+      socket,
+      user: 'fake user',
+      room: 'fake room',
+    };
+    emitStub = sinon.stub(socket, 'emit');
+    toStub = sinon.stub(socket, 'to').returns(socket);
+  });
+
+  afterEach(() => {
+    emitStub.restore();
+    toStub.restore();
+  });
+
+  context('acceptFromCallee', () => {
+    it('should throw error if payload is undefined', () => {
+      const errorMessage = `Invalid payload. payload: ${undefined}`;
+
+      expect(events.acceptFromCallee(fakeSession).bind(this)).to.throw(errorMessage);
+    });
+
+    it('should throw error if payload does not contain sdp', () => {
+      const invalidPayload = {};
+      const errorMessage = `Invalid payload. sdp: ${undefined}`;
+
+      expect(events.acceptFromCallee(fakeSession).bind(this, invalidPayload))
+        .to.throw(errorMessage);
+    });
+
+    it('should broadcast relay offer including sender info', () => {
+      const {
+        room,
+        user,
+      } = fakeSession;
+      const fakePayload = { sdp: 'fake sdp' };
+      const relayOfferPayload = {
+        sender: user,
+        sdp: fakePayload.sdp,
+      };
+
+      events.acceptFromCallee(fakeSession)(fakePayload);
+
+      expect(toStub).to.have.been.calledOnce;
+      expect(toStub).to.have.been.calledWith(room);
+      expect(emitStub).to.have.been.calledOnce;
+      expect(emitStub).to.have.been.calledWith('relay offer', relayOfferPayload);
+    });
+  });
+
+  context('acceptFromCalleeErrorHandler', () => {
+    it('should emit invalid accept payload error to client', () => {
+      const err = { message: 'fake message' };
+      const context = { session: fakeSession };
+      const errorPayload = {
+        code: 304,
+        description: 'Invalid Accept Payload',
+        message: err.message,
+      };
+
+      events.acceptFromCalleeErrorHandler(err, context);
+
+      expect(emitStub).to.have.been.calledOnce;
+      expect(emitStub).to.have.been.calledWith('SERVER_TO_PEER_ERROR', errorPayload);
+    });
+  });
+
+  context('rejectFromCallee', () => {
+    it('should emit bye to other clients', () => {
+      const {
+        room,
+        user,
+      } = fakeSession;
+      const byeEventPayload = { sender: user };
+
+      events.rejectFromCallee(fakeSession)();
+
+      expect(toStub).to.have.been.calledOnce;
+      expect(toStub).to.have.been.calledWith(room);
+      expect(emitStub).to.have.been.calledOnce;
+      expect(emitStub).to.have.been.calledWith('bye', byeEventPayload);
+    });
+  });
+
+  context('answerFromClient', () => {
+    it('should throw error if payload is undefined', () => {
+      const errorMessage = `Invalid payload. payload: ${undefined}`;
+
+      expect(events.answerFromClient(fakeSession).bind(this)).to.throw(errorMessage);
+    });
+
+    it('should throw error if payload doen not contain properties', () => {
+      const invalidPayloads = [
+        {},
+        { sdp: 'fake sdp', receiver: undefined },
+        { sdp: undefined, receiver: 'fake receiver' },
+      ];
+
+      invalidPayloads.forEach((payload) => {
+        const {
+          sdp,
+          receiver,
+        } = payload;
+        const errorMessage = `Invalid payload. sdp: ${sdp}, receiver: ${receiver}`;
+
+        expect(events.answerFromClient(fakeSession).bind(this, payload)).to.throw(errorMessage);
+      });
+    });
+
+    it('should emit relay answer event to receiver', () => {
+      const fakePayload = {
+        sdp: 'fake sdp',
+        receiver: 'fake receiver',
+      };
+      const relayAnswerPayload = {
+        sdp: fakePayload.sdp,
+        receiver: fakePayload.receiver,
+        sender: fakeSession.user,
+      };
+
+      events.answerFromClient(fakeSession)(relayAnswerPayload);
+
+      expect(toStub).to.have.been.calledOnce;
+      expect(toStub).to.have.been.calledWith(`user:${fakePayload.receiver}`);
+      expect(emitStub).to.have.been.calledOnce;
+      expect(emitStub).to.have.been.calledWith('relay answer', relayAnswerPayload);
+    });
+  });
+
+  context('answerFromClientErrorHandler', () => {
+    it('should emit error message to client', () => {
+      const err = { message: 'fake message' };
+      const context = { session: fakeSession };
+      const errorPayload = {
+        code: 305,
+        description: 'Invalid Send Answer Payload',
+        message: err.message,
+      };
+
+      events.answerFromClientErrorHandler(err, context);
+
+      expect(emitStub).to.have.been.calledOnce;
+      expect(emitStub).to.have.been.calledWith('SERVER_TO_PEER_ERROR', errorPayload);
+    });
+  });
+
+  context('icecandidateFromClient', () => {
+    it('should throw error if payload is undefined', () => {
+      const errMessage = `Invalid payload. payload: ${undefined}`;
+
+      expect(events.icecandidateFromClient(fakeSession).bind(this)).to.throw(errMessage);
+    });
+
+    it('should throw error if payload does not contain properties', () => {
+      const invalidPayloads = [
+        {},
+        { iceCandidate: undefined, receiver: 'fake receiver' },
+        { iceCandidate: 'fake icecandidate', receiver: undefined },
+      ];
+
+      invalidPayloads.forEach((payload) => {
+        const {
+          iceCandidate,
+          receiver,
+        } = payload;
+        const errMessage = `Invalid payload. iceCandidate: ${iceCandidate}, receiver: ${receiver}`;
+
+        expect(events.icecandidateFromClient(fakeSession).bind(this, payload)).to.throw(errMessage);
+      });
+    });
+
+    it('should relay icecandidate to receiver', () => {
+      const fakePayload = {
+        iceCandidate: 'fake icecandidate',
+        receiver: 'fake receiver',
+      };
+      const relayIcecandidatePayload = {
+        iceCandidate: fakePayload.iceCandidate,
+        receiver: fakePayload.receiver,
+        sender: fakeSession.user,
+      };
+
+      events.icecandidateFromClient(fakeSession)(fakePayload);
+
+      expect(toStub).to.have.been.calledOnce;
+      expect(toStub).to.have.been.calledWith(`user:${fakePayload.receiver}`);
+      expect(emitStub).to.have.been.calledOnce;
+      expect(emitStub).to.have.been.calledWith('relay icecandidate', relayIcecandidatePayload);
+    });
+  });
+
+  context('icecandidateFromClientErrorHandler', () => {
+    it('should emit error message to client', () => {
+      const err = { message: 'fake message' };
+      const context = { session: fakeSession };
+      const errorPayload = {
+        code: 306,
+        description: 'Invalid Send Icecandidate Payload',
+        message: err.message,
+      };
+
+      events.icecandidateFromClientErrorHandler(err, context);
+
+      expect(emitStub).to.have.been.calledOnce;
+      expect(emitStub).to.have.been.calledWith('SERVER_TO_PEER_ERROR', errorPayload);
+    });
+  });
+});


### PR DESCRIPTION
## abstract
세션 연결 설정 이벤트(Session Establishment Events, #81 )들을 구현하였습니다.

## draft상의 수정해야할 내용
-  relay offer, relay answer, relay icecandidate의 receiver 프로퍼티가 꼭 필요한 속성은 아닙니다.
(다만, 클라이언트 단의 유효성 검증으로서 사용 가능할것으로 보입니다.)
- ice candidate 용어 사용 통일 (icecandidate vs iceCandidate)
- 에러 코드 재정의 필요

## 코드상의 수정해야할 내용
- payload, session 유효성 검증 로직 추상화
- 일부 이벤트의 중복 로직 제거
- 일부 테스트의 중복 로직 제거
- 특정 유저에 direct message를 위해 create room, awaken에서 별도의 room 생성 및 bye에서의 room 제거 필요 
