### PR TITLE
[#89] 세션, 페이로드 유효성 검사 로직 분리

### DIFF
--- a/src/boyj/session_establishment_events.js
+++ b/src/boyj/session_establishment_events.js
@@ -1,3 +1,6 @@
+import { validatePayload } from './signaling_validations';
+import { code } from './signaling_error';
+
 /**
  * ACCEPT 이벤트의 핸들러
  *
@@ -5,51 +8,29 @@
  * @returns {Function}
  */
 const acceptFromCallee = session => (payload) => {
-  if (!payload) {
-    throw new Error(`Invalid payload. payload: ${payload}`);
-  }
+  validatePayload({
+    payload,
+    props: ['sdp'],
+    options: { code: code.INVALID_ACCEPT_PAYLOAD },
+  });
 
   const { sdp } = payload;
 
-  if (!sdp) {
-    throw new Error(`Invalid payload. sdp: ${sdp}`);
-  }
-
-  // TODO: session 객체에 대한 유효성 검사 필요.
   const {
     user,
     room,
     socket,
   } = session;
 
-  socket.join(room);
-
   const relayOfferPayload = {
     sender: user,
     sdp,
   };
 
+  socket.join([room, `user:${user}`]);
+
   // 송신자를 제외한 나머지 클라이언트에 브로드캐스팅
   socket.to(room).emit('RELAY_OFFER', relayOfferPayload);
-};
-
-/**
- * ACCEPT 이벤트의 에러 핸들러
- *
- * @param err
- * @param context
- */
-const acceptFromCalleeErrorHandler = (err, context) => {
-  const { message } = err;
-  const { session } = context;
-  const { socket } = session;
-  const payload = {
-    code: 304,
-    description: 'Invalid ACCEPT Payload',
-    message,
-  };
-
-  socket.emit('SERVER_TO_PEER_ERROR', payload);
 };
 
 /**
@@ -59,15 +40,13 @@ const acceptFromCalleeErrorHandler = (err, context) => {
  * @returns {Function}
  */
 const rejectFromCallee = session => (payload) => {
-  if (!payload) {
-    throw new Error(`Invalid payload. payload: ${payload}`);
-  }
+  validatePayload({
+    payload,
+    props: ['receiver'],
+    options: { code: code.INVALID_REJECT_PAYLOAD },
+  });
 
   const { receiver } = payload;
-
-  if (!receiver) {
-    throw new Error(`Invalid payload. receiver: ${receiver}`);
-  }
 
   const {
     user,
@@ -79,27 +58,7 @@ const rejectFromCallee = session => (payload) => {
     receiver,
   };
 
-  // TODO: 세션 유효성 검사 필요.
   socket.to(`user:${receiver}`).emit('NOTIFY_REJECT', notifyRejectPayload);
-};
-
-/**
- * REJECT 이벤트의 에러 핸들러
- *
- * @param err
- * @param context
- */
-const rejectFromCalleeErrorHandler = (err, context) => {
-  const { message } = err;
-  const { session } = context;
-  const { socket } = session;
-  const errorPayload = {
-    code: 307,
-    description: 'Invalid REJECT Payload',
-    message,
-  };
-
-  socket.emit('SERVER_TO_PEER_ERROR', errorPayload);
 };
 
 /**
@@ -109,20 +68,17 @@ const rejectFromCalleeErrorHandler = (err, context) => {
  * @returns {Function}
  */
 const answerFromClient = session => (payload) => {
-  if (!payload) {
-    throw new Error(`Invalid payload. payload: ${payload}`);
-  }
+  validatePayload({
+    payload,
+    props: ['sdp', 'receiver'],
+    options: { code: code.INVALID_ANSWER_PAYLOAD },
+  });
 
   const {
     sdp,
     receiver,
   } = payload;
 
-  if (!sdp || !receiver) {
-    throw new Error(`Invalid payload. sdp: ${sdp}, receiver: ${receiver}`);
-  }
-
-  // TODO: 세션 유효성 검사 필요.
   const {
     user,
     socket,
@@ -137,45 +93,23 @@ const answerFromClient = session => (payload) => {
 };
 
 /**
- * ANSWER 이벤트의 에러 핸들러
- *
- * @param err
- * @param context
- */
-const answerFromClientErrorHandler = (err, context) => {
-  const { message } = err;
-  const { session } = context;
-  const { socket } = session;
-  const errorPayload = {
-    code: 305,
-    description: 'Invalid ANSWER Payload',
-    message,
-  };
-
-  socket.emit('SERVER_TO_PEER_ERROR', errorPayload);
-};
-
-/**
  * SEND_ICE_CANDIDATE 이벤트 핸들러
  *
  * @param session
  * @returns {Function}
  */
 const iceCandidateFromClient = session => (payload) => {
-  if (!payload) {
-    throw new Error(`Invalid payload. payload: ${payload}`);
-  }
+  validatePayload({
+    payload,
+    props: ['iceCandidate', 'receiver'],
+    options: { code: code.INVALID_SEND_ICE_CANDIDATE_PAYLOAD },
+  });
 
   const {
     iceCandidate,
     receiver,
   } = payload;
 
-  if (!iceCandidate || !receiver) {
-    throw new Error(`Invalid payload. iceCandidate: ${iceCandidate}, receiver: ${receiver}`);
-  }
-
-  // TODO: 세션 유효성 검사 필요.
   const {
     user,
     socket,
@@ -189,32 +123,9 @@ const iceCandidateFromClient = session => (payload) => {
   socket.to(`user:${receiver}`).emit('RELAY_ICE_CANDIDATE', relayIceCandidatePayload);
 };
 
-/**
- * send icecandidate 이벤트의 에러 핸들러
- *
- * @param err
- * @param context
- */
-const iceCandidateFromClientErrorHandler = (err, context) => {
-  const { message } = err;
-  const { session } = context;
-  const { socket } = session;
-  const errorPayload = {
-    code: 306,
-    description: 'Invalid SEND_ICE_CANDIDATE Payload',
-    message,
-  };
-
-  socket.emit('SERVER_TO_PEER_ERROR', errorPayload);
-};
-
 export {
   acceptFromCallee,
-  acceptFromCalleeErrorHandler,
   rejectFromCallee,
-  rejectFromCalleeErrorHandler,
   answerFromClient,
-  answerFromClientErrorHandler,
   iceCandidateFromClient,
-  iceCandidateFromClientErrorHandler,
 };

--- a/src/boyj/signaling_error.js
+++ b/src/boyj/signaling_error.js
@@ -1,0 +1,38 @@
+const descriptionTable = {
+  300: 'Internal Server Error',
+  301: 'Invalid CREATE_ROOM Payload',
+  302: 'Invalid DIAL Payload',
+  303: 'Invalid AWAKEN Payload',
+  304: 'Invalid ACCEPT Payload',
+  305: 'Invalid ANSWER Payload',
+  306: 'Invalid SEND_ICE_CANDIDATE Payload',
+  307: 'Invalid REJECT Payload',
+};
+
+const code = {
+  INTERNAL_SERVER_ERROR: 300,
+  INVALID_CREATE_ROOM_PAYLOAD: 301,
+  INVALID_DIAL_PAYLOAD: 302,
+  INVALID_AWAKEN_PAYLOAD: 303,
+  INVALID_ACCEPT_PAYLOAD: 304,
+  INVALID_ANSWER_PAYLOAD: 305,
+  INVALID_SEND_ICE_CANDIDATE_PAYLOAD: 306,
+  INVALID_REJECT_PAYLOAD: 307,
+};
+
+class SignalingError extends Error {
+  constructor(message, options = {}) {
+    super();
+
+    this.name = this.constructor.name;
+    this.message = message;
+    this.code = options.code || 300;
+    this.description = options.description || descriptionTable[this.code];
+  }
+}
+
+export {
+  descriptionTable,
+  code,
+  SignalingError,
+};

--- a/src/boyj/signaling_error_handler.js
+++ b/src/boyj/signaling_error_handler.js
@@ -1,0 +1,44 @@
+import {
+  SignalingError,
+  code as errorCode,
+  descriptionTable,
+} from './signaling_error';
+import logger from '../logger';
+
+/**
+ * 시그널링 이벤트 핸들러에서 에러 발생시의 에러 핸들러
+ * 정의된 에러의 경우 해당 에러 코드(30x)와 그에 대한 설명,
+ * 그 외의 경우 기본 에러 코드(300)과 그에 대한 설명이 상대에 전달된다.
+ *
+ * @param err: 발생된 에러 객체
+ * @param context: session, payload 등을 갖고있는 컨텍스트 객체
+ */
+const signalingErrorHandler = (err, context) => {
+  const code = (err instanceof SignalingError)
+    ? err.code
+    : errorCode.INTERNAL_SERVER_ERROR;
+  const description = (err instanceof SignalingError)
+    ? err.description
+    : descriptionTable[code];
+  const { message } = err;
+  const { session } = context;
+  const {
+    socket,
+    room,
+    user,
+  } = session;
+
+  logger.error({
+    err,
+    room,
+    user,
+  });
+
+  socket.emit('SERVER_TO_PEER_ERROR', {
+    code,
+    description,
+    message,
+  });
+};
+
+export default signalingErrorHandler;

--- a/src/boyj/signaling_validations.js
+++ b/src/boyj/signaling_validations.js
@@ -1,0 +1,72 @@
+/* eslint-disable no-prototype-builtins */
+import { SignalingError, code } from './signaling_error';
+
+/**
+ * 유효성 규칙들.
+ * payload의 각 property를 키값으로 해당 property에 대한 유효성 검증 로직을 갖는다.
+ */
+const rules = {
+  room: (payload, prop) => !payload.hasOwnProperty(prop) || !payload[prop],
+  callerId: (payload, prop) => !payload.hasOwnProperty(prop) || !payload[prop],
+  calleeId: (payload, prop) => !payload.hasOwnProperty(prop) || !payload[prop],
+  sender: (payload, prop) => !payload.hasOwnProperty(prop) || !payload[prop],
+  receiver: (payload, prop) => !payload.hasOwnProperty(prop) || !payload[prop],
+  sdp: (payload, prop) => !payload.hasOwnProperty(prop) || !payload[prop],
+  iceCandidate: (payload, prop) => !payload.hasOwnProperty(prop) || !payload[prop],
+  DEFAULT_PROPERTY_RULE: (payload, prop) => !payload.hasOwnProperty(prop) || !payload[prop],
+};
+
+/**
+ * 인자로 받은 payload의 property 각각을 정해진 규칙에 의해 유효성 검사
+ *
+ * @param payload
+ * @param props
+ * @param options
+ */
+const validatePayload = ({
+  payload = {},
+  props = [],
+  options,
+}) => {
+  const invalidProperties = props.filter((prop) => {
+    const rule = rules[prop] || rules.DEFAULT_PROPERTY_RULE;
+    return rule(payload, prop);
+  });
+
+  if (invalidProperties.length === 0) {
+    return;
+  }
+
+  const errorDetails = invalidProperties
+    .map(prop => `${prop}: ${payload[prop]}`)
+    .join(', ');
+  const message = `Invalid payload. ${errorDetails}`;
+
+  throw new SignalingError(message, options);
+};
+
+/**
+ * 시그널링 이벤트 핸들링에 앞서 세션의 초기화 여부를 확인.
+ *
+ * @param callback
+ * @returns {function(*=): Function}
+ */
+const withSession = callback => session => async (payload) => {
+  const {
+    user,
+    room,
+  } = session;
+
+  if (!user || !room) {
+    throw new SignalingError('Session is not initialized', {
+      options: { code: code.INTERNAL_SERVER_ERROR },
+    });
+  }
+
+  await callback(session)(payload);
+};
+
+export {
+  validatePayload,
+  withSession,
+};


### PR DESCRIPTION
#89 
## Abstract
각 시그널링 이벤트에서 진행했던 유효성 검사 로직을 분리하였습니다.
이에 따라 테스트 케이스와 에러 핸들러 일부가 제거되었습니다.

## entry points
### session validation
```signaling_validations.js```의 ```withSession``` 함수
-> ```src/index.js```의 ```on(...)``` 함수 

### payload validation
```signaling_error.js```
-> ```signaling_validations.js```의 ```validatePayload``` 함수
-> 각 이벤트 핸들러의 ```validationPayload``` 호출 부분

## reference
간단하게 caller, callee 2자간의 통신을 진행하였습니다.
메시지 시퀀스와 로그는 [위키문서](https://github.com/the-boyj/wiki/wiki/Logging-for-Signaling-Server-v2.0)에 기록하였습니다.