### PR TITLE
replace sdp, icecandidate fit in android webRTC

### DIFF
--- a/src/boyj/session_establishment_events.js
+++ b/src/boyj/session_establishment_events.js
@@ -114,6 +114,11 @@ const answerFromClient = session => (payload) => {
     receiver,
   } = payload;
 
+  if (!sdp.description) {
+    sdp.description = sdp.sdp;
+  }
+  sdp.type = sdp.type.toUpperCase();
+
   const {
     user,
     socket,
@@ -144,6 +149,10 @@ const iceCandidateFromClient = session => (payload) => {
     iceCandidate,
     receiver,
   } = payload;
+
+  if (!iceCandidate.candidate) {
+    iceCandidate.candidate = iceCandidate.sdp;
+  }
 
   const {
     user,


### PR DESCRIPTION
1. sdp payload가 다름
```

 웹클라이언트 :
   sdp : {
      sdp,
      type: 소문자
   }
 안드로이드:
  sdp : {
      description
      type: 대문자
  }
```

2. ICE Candidate payload가 다름
```
웹클라이언트 :
   candidate: {
      sdp,
   }

안드로이드: {
   candidate: {
      candidate,
  } 
```